### PR TITLE
feat: add input argument to read input from text or stdin

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -11,17 +11,26 @@ struct Args {
     /// The replacement pattern.
     #[arg(short, long)]
     replace: String,
+
+    /// The input content to search and replace. If not provided, input will be read from stdin.
+    #[arg(short, long)]
+    input: Option<String>,
 }
 
 fn main() {
     let args = Args::parse();
 
-    let mut input = String::new();
-    match std::io::stdin().read_to_string(&mut input) {
-        Ok(_) => (),
-        Err(err) => {
-            eprintln!("Error reading from stdin: {}", err);
-            return;
+    let input = match args.input {
+        Some(input) => input,
+        None => {
+            let mut input = String::new();
+            match std::io::stdin().read_to_string(&mut input) {
+                Ok(_) => input,
+                Err(err) => {
+                    eprintln!("Error reading from stdin: {}", err);
+                    return;
+                }
+            }
         }
     };
 


### PR DESCRIPTION
feat: add input argument to read input from text or stdin

You can now provide input as the content you want to search and replace in. If
you don't provide input, the program will read from stdin.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/AdeAttwood/DevCase/pull/3).
* #4
* __->__ #3