### PR TITLE
fix: handle invalid regex patterns by returning the input string

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,10 @@ fn concert_replacement(original: &str, replacement: &str) -> String {
 pub fn replace(search: &String, replace: String, input: String) -> String {
     let mut index = 0;
     let mut output = input;
-    let search_pattern = Regex::new(&format!("(?i){search}")).unwrap();
+    let search_pattern = match Regex::new(&format!("(?i){search}")) {
+        Ok(pattern) => pattern,
+        Err(_) => return output,
+    };
 
     while let Some(search_match) = search_pattern.find_at(&output, index) {
         let start = search_match.start();

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,17 +11,26 @@ struct Args {
     /// The replacement pattern.
     #[arg(short, long)]
     replace: String,
+
+    /// The input content to search and replace. If not provided, input will be read from stdin.
+    #[arg(short, long)]
+    input: Option<String>,
 }
 
 fn main() {
     let args = Args::parse();
 
-    let mut input = String::new();
-    match std::io::stdin().read_to_string(&mut input) {
-        Ok(_) => (),
-        Err(err) => {
-            eprintln!("Error reading from stdin: {}", err);
-            return;
+    let input = match args.input {
+        Some(input) => input,
+        None => {
+            let mut input = String::new();
+            match std::io::stdin().read_to_string(&mut input) {
+                Ok(_) => input,
+                Err(err) => {
+                    eprintln!("Error reading from stdin: {}", err);
+                    return;
+                }
+            }
         }
     };
 

--- a/tests/features/regex.feature
+++ b/tests/features/regex.feature
@@ -17,3 +17,9 @@ Feature: Regex search and replace
     And Replace is 'Hello ${1}s'
     And Input is 'Hello world'
     Then Output is 'Hello worlds'
+
+  Scenario: You can search with an invalid regular expression
+    Given Search is '(\w+'
+    And Replace is 'new'
+    And Input is 'this is a'
+    Then Output is 'this is a' 


### PR DESCRIPTION
fix: handle invalid regex patterns by returning the input string

Right now we don't want to be panicking if the user provides an invalid regex.
We also don't really want to be throwing or returning an error, this will mess
with any live preview that is going on in external tools.

We should return the input and let any preview display the text. This will
happen if the user is doing some preview as you type kind of thing.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/AdeAttwood/DevCase/pull/4).
* __->__ #4
* #3